### PR TITLE
PaymentFactory creates PreauthorizedPayment so that money can be just blocked

### DIFF
--- a/src/Api/Entity/PaymentFactory.php
+++ b/src/Api/Entity/PaymentFactory.php
@@ -37,6 +37,7 @@ class PaymentFactory
 		'additional_params',
 		'lang',
 		'eet',
+		'preauthorization',
 	];
 
 	/** @var array */
@@ -48,7 +49,7 @@ class PaymentFactory
 	/**
 	 * @param mixed $data
 	 * @param array $validators
-	 * @return Payment
+	 * @return PreauthorizedPayment
 	 */
 	public static function create($data, $validators = [])
 	{
@@ -74,7 +75,7 @@ class PaymentFactory
 
 		// CREATE PAYMENT ########################
 
-		$payment = new Payment();
+		$payment = new PreauthorizedPayment();
 
 		// ### PAYER
 		if (isset($data['payer'])) {
@@ -108,6 +109,11 @@ class PaymentFactory
 			$target = new Target;
 			self::map($target, ['type' => 'type', 'goid' => 'goid'], $data['target']);
 			$payment->setTarget($target);
+		}
+
+		// ### PREAUTHORIZATION
+		if (isset($data['preauthorization'])) {
+			$payment->setPreauthorization($data['preauthorization']);
 		}
 
 		// ### COMMON

--- a/src/Api/Entity/PreauthorizedPayment.php
+++ b/src/Api/Entity/PreauthorizedPayment.php
@@ -5,8 +5,8 @@ namespace Contributte\GopayInline\Api\Entity;
 class PreauthorizedPayment extends Payment
 {
 
-	/** @var bool */
-	protected $preauthorization = false;
+	/** @var boolean */
+	protected $preauthorization = FALSE;
 
 	/**
 	 * @return boolean

--- a/src/Api/Entity/PreauthorizedPayment.php
+++ b/src/Api/Entity/PreauthorizedPayment.php
@@ -6,7 +6,7 @@ class PreauthorizedPayment extends Payment
 {
 
 	/** @var bool */
-	protected $preauthorization;
+	protected $preauthorization = false;
 
 	/**
 	 * @return boolean

--- a/tests/cases/unit/Api/Entity/PaymentFactory.phpt
+++ b/tests/cases/unit/Api/Entity/PaymentFactory.phpt
@@ -96,7 +96,7 @@ test(function () {
 	Assert::type(Eet::class, $payment->getEet());
 	Assert::false($payment->isPreauthorization());
 
-	$payment->setPreauthorization(true);
+	$payment->setPreauthorization(TRUE);
 	Assert::true($payment->isPreauthorization());
 });
 

--- a/tests/cases/unit/Api/Entity/PaymentFactory.phpt
+++ b/tests/cases/unit/Api/Entity/PaymentFactory.phpt
@@ -94,6 +94,10 @@ test(function () {
 	Assert::equal(21, $payment->getItems()[2]->getVatRate());
 	Assert::equal(PaymentType::ITEM, $payment->getItems()[3]->getType());
 	Assert::type(Eet::class, $payment->getEet());
+	Assert::false($payment->isPreauthorization());
+
+	$payment->setPreauthorization(true);
+	Assert::true($payment->isPreauthorization());
 });
 
 // Validate order price and items price


### PR DESCRIPTION
Currently there is no way to create preauthorized payment. This commit changes Payment to PreauthorizedPayment class so that the ```preauthorized``` flag can be set. The default value is set to ```false```, so there should be no back compatibility issues.