### PR TITLE
Rename to Contributte

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Markette
+Copyright (c) 2015, Contributte
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Install **Markette/GopayInline** over composer.
 $ composer require markette/gopay-inline
 ```
 
+Why is the package still called Markette? Because we don't want to break other people's projects (for now).
+
 ## Requirements
 
 From GoPay you need:

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
-# Markette :: GopayInline
+# Contributte :: GopayInline
 
-[![Build Status](https://img.shields.io/travis/Markette/GopayInline.svg?style=flat-square)](https://travis-ci.org/Markette/GopayInline)
-[![Code coverage](https://img.shields.io/coveralls/Markette/GopayInline.svg?style=flat-square)](https://coveralls.io/r/Markette/GopayInline)
+[![Build Status](https://img.shields.io/travis/Contributte/GopayInline.svg?style=flat-square)](https://travis-ci.org/contributte/gopay-inline)
+[![Code coverage](https://img.shields.io/coveralls/Contributte/GopayInline.svg?style=flat-square)](https://coveralls.io/r/Contributte/GopayInline)
 [![Downloads latests](https://img.shields.io/packagist/dt/markette/gopay-inline.svg?style=flat-square)](https://packagist.org/packages/markette/gopay-inline)
 [![Latest stable](https://img.shields.io/packagist/v/markette/gopay-inline.svg?style=flat-square)](https://packagist.org/packages/markette/gopay-inline)
-[![HHVM Status](https://img.shields.io/hhvm/markette/gopay-inline.svg?style=flat-square)](http://hhvm.h4cc.de/package/markette/gopay-inline)
 
 ## Discussion
 
-[![Join the chat at https://gitter.im/Markette/Gopay](https://img.shields.io/gitter/room/Markette/Gopay.svg?style=flat-square)](https://gitter.im/Markette/Gopay?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/Contributte/Gopay](https://img.shields.io/gitter/room/Contributte/Gopay.svg?style=flat-square)](https://gitter.im/Contributte/Gopay?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Prolog
 
@@ -43,7 +42,7 @@ On server you need:
 
 ## Examples
 
-All you can find in [examples folder](https://github.com/Markette/GopayInline/blob/master/examples).
+All you can find in [examples folder](https://github.com/Contributte/GopayInline/blob/master/examples).
 
 ## Library
 
@@ -75,8 +74,8 @@ Services provide easy-to-use API for creating and verifying payments.
 First you need set up client with credentials.
 
 ```php
-use Markette\GopayInline\Client;
-use Markette\GopayInline\Config;
+use Contributte\GopayInline\Client;
+use Contributte\GopayInline\Config;
 
 $goId = 'GoID';
 $clientId = 'ClientID';
@@ -95,7 +94,7 @@ Then you have to authenticate with oauth2 authority server on GoPay.
 For only creating payments use `Scope::PAYMENT_CREATE`, for the rest `Scope::PAYMENT_ALL`.
 
 ```php
-use Markette\GopayInline\Api\Lists\Scope;
+use Contributte\GopayInline\Api\Lists\Scope;
 
 $token = $client->authenticate(['scope' => Scope::PAYMENT_CREATE]);
 ```
@@ -107,11 +106,11 @@ Heureka! We have token, let's make some API request.
 This example of payment data was copied from official documentation.
 
 ```php
-use Markette\GopayInline\Api\Entity\PaymentFactory;
-use Markette\GopayInline\Api\Lists\Currency;
-use Markette\GopayInline\Api\Lists\Language;
-use Markette\GopayInline\Api\Lists\PaymentInstrument;
-use Markette\GopayInline\Api\Lists\SwiftCode;
+use Contributte\GopayInline\Api\Entity\PaymentFactory;
+use Contributte\GopayInline\Api\Lists\Currency;
+use Contributte\GopayInline\Api\Lists\Language;
+use Contributte\GopayInline\Api\Lists\PaymentInstrument;
+use Contributte\GopayInline\Api\Lists\SwiftCode;
 
 $payment = [
 	'payer' => [
@@ -122,10 +121,10 @@ $payment = [
 		'contact' => [
 			'first_name' => 'John',
 			'last_name' => 'Doe',
-			'email' => 'johndoe@markette.org',
+			'email' => 'johndoe@contributte.org',
 			'phone_number' => '+420123456789',
 			'city' => 'Prague',
-			'street' => 'Markette 123',
+			'street' => 'Contributte 123',
 			'postal_code' => '123 45',
 			'country_code' => 'CZE',
 		],
@@ -175,7 +174,7 @@ only with one **payment instrument**, for example only with `BANK_ACCOUNT` or `P
 #### For ALL payment instruments
 
 ```php
-use Markette\GopayInline\Api\Lists\PaymentInstrument;
+use Contributte\GopayInline\Api\Lists\PaymentInstrument;
 
 $payment['payer']['allowed_payment_instruments']= PaymentInstrument::all();
 ```
@@ -185,7 +184,7 @@ $payment['payer']['allowed_payment_instruments']= PaymentInstrument::all();
 Use `allowed_swifts` and `default_swift` only with `BANK_ACCOUNT`.
 
 ```php
-use Markette\GopayInline\Api\Lists\SwiftCode;
+use Contributte\GopayInline\Api\Lists\SwiftCode;
 
 $payment['payer']['allowed_swifts']= SwiftCode::all();
 // or
@@ -219,7 +218,7 @@ $url = $response['gw_url'];
 // ...
 ```
 
-In case of inline variant you can use prepared [javascript](https://github.com/Markette/GopayInline/blob/master/client-side) (under development at this moment).
+In case of inline variant you can use prepared [javascript](https://github.com/Contributte/GopayInline/blob/master/client-side) (under development at this moment).
 
 ### Verify payment (check state)
 
@@ -238,7 +237,7 @@ Fill your credentials in config.
 
 ```yaml
 extensions:
-    gopay: Markette\GopayInline\Bridges\Nette\DI\GopayExtension
+    gopay: Contributte\GopayInline\Bridges\Nette\DI\GopayExtension
 
 gopay:
     goId: ***
@@ -250,7 +249,7 @@ gopay:
 Inject `Client` into your services / presenters;
 
 ```php
-use Markette\GopayInline\Client;
+use Contributte\GopayInline\Client;
 
 /** @var Client @inject */
 public $gopay;

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "markette/gopay-inline",
 	"description": "GoPay Inline Payment Gateway",
 	"keywords": ["eshop", "payment", "gopay", "api", "inline"],
-	"homepage": "https://github.com/Markette/GopayInline",
+	"homepage": "https://github.com/Contributte/GopayInline",
 	"license": "BSD-3-Clause",
 	"authors": [
 		{
@@ -27,7 +27,7 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"Markette\\GopayInline\\": "src/"
+			"Contributte\\GopayInline\\": "src/"
 		}
 	},
 	"scripts": {

--- a/examples/authenticate.php
+++ b/examples/authenticate.php
@@ -1,8 +1,8 @@
 <?php
 
-use Markette\GopayInline\Api\Lists\Scope;
-use Markette\GopayInline\Client;
-use Markette\GopayInline\Config;
+use Contributte\GopayInline\Api\Lists\Scope;
+use Contributte\GopayInline\Client;
+use Contributte\GopayInline\Config;
 
 // Load composer
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/examples/create.php
+++ b/examples/create.php
@@ -1,12 +1,12 @@
 <?php
 
-use Markette\GopayInline\Api\Entity\PaymentFactory;
-use Markette\GopayInline\Api\Lists\Currency;
-use Markette\GopayInline\Api\Lists\Language;
-use Markette\GopayInline\Api\Lists\PaymentInstrument;
-use Markette\GopayInline\Api\Lists\SwiftCode;
-use Markette\GopayInline\Client;
-use Markette\GopayInline\Config;
+use Contributte\GopayInline\Api\Entity\PaymentFactory;
+use Contributte\GopayInline\Api\Lists\Currency;
+use Contributte\GopayInline\Api\Lists\Language;
+use Contributte\GopayInline\Api\Lists\PaymentInstrument;
+use Contributte\GopayInline\Api\Lists\SwiftCode;
+use Contributte\GopayInline\Client;
+use Contributte\GopayInline\Config;
 
 // Load composer
 require_once __DIR__ . '/../vendor/autoload.php';
@@ -28,10 +28,10 @@ $payment = [
 		'contact' => [
 			'first_name' => 'John',
 			'last_name' => 'Doe',
-			'email' => 'johndoe@markette.org',
+			'email' => 'johndoe@contributte.org',
 			'phone_number' => '+420123456789',
 			'city' => 'Prague',
-			'street' => 'Markette 123',
+			'street' => 'Contributte 123',
 			'postal_code' => '123 45',
 			'country_code' => 'CZE',
 		],

--- a/examples/modes.php
+++ b/examples/modes.php
@@ -1,7 +1,7 @@
 <?php
 
-use Markette\GopayInline\Client;
-use Markette\GopayInline\Config;
+use Contributte\GopayInline\Client;
+use Contributte\GopayInline\Config;
 
 // Load composer
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/examples/verify.php
+++ b/examples/verify.php
@@ -1,7 +1,7 @@
 <?php
 
-use Markette\GopayInline\Client;
-use Markette\GopayInline\Config;
+use Contributte\GopayInline\Client;
+use Contributte\GopayInline\Config;
 
 // Load composer
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/src/Api/Entity/AbstractEntity.php
+++ b/src/Api/Entity/AbstractEntity.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Entity;
+namespace Contributte\GopayInline\Api\Entity;
 
 abstract class AbstractEntity
 {

--- a/src/Api/Entity/Payment.php
+++ b/src/Api/Entity/Payment.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Markette\GopayInline\Api\Entity;
+namespace Contributte\GopayInline\Api\Entity;
 
-use Markette\GopayInline\Api\Objects\Eet;
-use Markette\GopayInline\Api\Objects\Item;
-use Markette\GopayInline\Api\Objects\Parameter;
-use Markette\GopayInline\Api\Objects\Payer;
-use Markette\GopayInline\Api\Objects\Target;
-use Markette\GopayInline\Utils\Money;
+use Contributte\GopayInline\Api\Objects\Eet;
+use Contributte\GopayInline\Api\Objects\Item;
+use Contributte\GopayInline\Api\Objects\Parameter;
+use Contributte\GopayInline\Api\Objects\Payer;
+use Contributte\GopayInline\Api\Objects\Target;
+use Contributte\GopayInline\Utils\Money;
 
 class Payment extends AbstractEntity
 {

--- a/src/Api/Entity/PaymentFactory.php
+++ b/src/Api/Entity/PaymentFactory.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Markette\GopayInline\Api\Entity;
+namespace Contributte\GopayInline\Api\Entity;
 
-use Markette\GopayInline\Api\Objects\Contact;
-use Markette\GopayInline\Api\Objects\Eet;
-use Markette\GopayInline\Api\Objects\Item;
-use Markette\GopayInline\Api\Objects\Parameter;
-use Markette\GopayInline\Api\Objects\Payer;
-use Markette\GopayInline\Api\Objects\Target;
-use Markette\GopayInline\Exception\ValidationException;
-use Markette\GopayInline\Utils\Validator;
+use Contributte\GopayInline\Api\Objects\Contact;
+use Contributte\GopayInline\Api\Objects\Eet;
+use Contributte\GopayInline\Api\Objects\Item;
+use Contributte\GopayInline\Api\Objects\Parameter;
+use Contributte\GopayInline\Api\Objects\Payer;
+use Contributte\GopayInline\Api\Objects\Target;
+use Contributte\GopayInline\Exception\ValidationException;
+use Contributte\GopayInline\Utils\Validator;
 
 class PaymentFactory
 {

--- a/src/Api/Entity/PreauthorizedPayment.php
+++ b/src/Api/Entity/PreauthorizedPayment.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Entity;
+namespace Contributte\GopayInline\Api\Entity;
 
 class PreauthorizedPayment extends Payment
 {

--- a/src/Api/Entity/RecurrentPayment.php
+++ b/src/Api/Entity/RecurrentPayment.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Markette\GopayInline\Api\Entity;
+namespace Contributte\GopayInline\Api\Entity;
 
-use Markette\GopayInline\Api\Objects\Recurrence;
+use Contributte\GopayInline\Api\Objects\Recurrence;
 
 class RecurrentPayment extends Payment
 {

--- a/src/Api/Entity/RecurrentPaymentFactory.php
+++ b/src/Api/Entity/RecurrentPaymentFactory.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Markette\GopayInline\Api\Entity;
+namespace Contributte\GopayInline\Api\Entity;
 
-use Markette\GopayInline\Api\Objects\Contact;
-use Markette\GopayInline\Api\Objects\Eet;
-use Markette\GopayInline\Api\Objects\Item;
-use Markette\GopayInline\Api\Objects\Parameter;
-use Markette\GopayInline\Api\Objects\Payer;
-use Markette\GopayInline\Api\Objects\Recurrence;
-use Markette\GopayInline\Api\Objects\Target;
-use Markette\GopayInline\Exception\ValidationException;
-use Markette\GopayInline\Utils\Validator;
+use Contributte\GopayInline\Api\Objects\Contact;
+use Contributte\GopayInline\Api\Objects\Eet;
+use Contributte\GopayInline\Api\Objects\Item;
+use Contributte\GopayInline\Api\Objects\Parameter;
+use Contributte\GopayInline\Api\Objects\Payer;
+use Contributte\GopayInline\Api\Objects\Recurrence;
+use Contributte\GopayInline\Api\Objects\Target;
+use Contributte\GopayInline\Exception\ValidationException;
+use Contributte\GopayInline\Utils\Validator;
 
 class RecurrentPaymentFactory
 {

--- a/src/Api/Entity/RecurringPayment.php
+++ b/src/Api/Entity/RecurringPayment.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Entity;
+namespace Contributte\GopayInline\Api\Entity;
 
 class RecurringPayment extends Payment
 {

--- a/src/Api/Entity/RecurringPaymentFactory.php
+++ b/src/Api/Entity/RecurringPaymentFactory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Markette\GopayInline\Api\Entity;
+namespace Contributte\GopayInline\Api\Entity;
 
-use Markette\GopayInline\Api\Objects\Item;
-use Markette\GopayInline\Api\Objects\Parameter;
-use Markette\GopayInline\Exception\ValidationException;
-use Markette\GopayInline\Utils\Validator;
+use Contributte\GopayInline\Api\Objects\Item;
+use Contributte\GopayInline\Api\Objects\Parameter;
+use Contributte\GopayInline\Exception\ValidationException;
+use Contributte\GopayInline\Utils\Validator;
 
 class RecurringPaymentFactory
 {

--- a/src/Api/Gateway.php
+++ b/src/Api/Gateway.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api;
+namespace Contributte\GopayInline\Api;
 
 class Gateway
 {

--- a/src/Api/Lists/Currency.php
+++ b/src/Api/Lists/Currency.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Lists;
+namespace Contributte\GopayInline\Api\Lists;
 
 class Currency
 {

--- a/src/Api/Lists/Format.php
+++ b/src/Api/Lists/Format.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Lists;
+namespace Contributte\GopayInline\Api\Lists;
 
 class Format
 {

--- a/src/Api/Lists/Language.php
+++ b/src/Api/Lists/Language.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Lists;
+namespace Contributte\GopayInline\Api\Lists;
 
 class Language
 {

--- a/src/Api/Lists/PaymentInstrument.php
+++ b/src/Api/Lists/PaymentInstrument.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Lists;
+namespace Contributte\GopayInline\Api\Lists;
 
 class PaymentInstrument
 {

--- a/src/Api/Lists/PaymentState.php
+++ b/src/Api/Lists/PaymentState.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Lists;
+namespace Contributte\GopayInline\Api\Lists;
 
 class PaymentState
 {

--- a/src/Api/Lists/PaymentType.php
+++ b/src/Api/Lists/PaymentType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Lists;
+namespace Contributte\GopayInline\Api\Lists;
 
 class PaymentType
 {

--- a/src/Api/Lists/RecurrenceCycle.php
+++ b/src/Api/Lists/RecurrenceCycle.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Lists;
+namespace Contributte\GopayInline\Api\Lists;
 
 class RecurrenceCycle
 {

--- a/src/Api/Lists/RecurrenceState.php
+++ b/src/Api/Lists/RecurrenceState.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Lists;
+namespace Contributte\GopayInline\Api\Lists;
 
 class RecurrenceState
 {

--- a/src/Api/Lists/Result.php
+++ b/src/Api/Lists/Result.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Lists;
+namespace Contributte\GopayInline\Api\Lists;
 
 class Result
 {

--- a/src/Api/Lists/Scope.php
+++ b/src/Api/Lists/Scope.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Lists;
+namespace Contributte\GopayInline\Api\Lists;
 
 class Scope
 {

--- a/src/Api/Lists/SwiftCode.php
+++ b/src/Api/Lists/SwiftCode.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Lists;
+namespace Contributte\GopayInline\Api\Lists;
 
 class SwiftCode
 {

--- a/src/Api/Lists/TargetType.php
+++ b/src/Api/Lists/TargetType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Lists;
+namespace Contributte\GopayInline\Api\Lists;
 
 class TargetType
 {

--- a/src/Api/Lists/VatRate.php
+++ b/src/Api/Lists/VatRate.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Lists;
+namespace Contributte\GopayInline\Api\Lists;
 
 class VatRate
 {

--- a/src/Api/Objects/AbstractObject.php
+++ b/src/Api/Objects/AbstractObject.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Objects;
+namespace Contributte\GopayInline\Api\Objects;
 
 abstract class AbstractObject
 {

--- a/src/Api/Objects/Contact.php
+++ b/src/Api/Objects/Contact.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Objects;
+namespace Contributte\GopayInline\Api\Objects;
 
 class Contact extends AbstractObject
 {

--- a/src/Api/Objects/Eet.php
+++ b/src/Api/Objects/Eet.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Markette\GopayInline\Api\Objects;
+namespace Contributte\GopayInline\Api\Objects;
 
-use Markette\GopayInline\Utils\Money;
+use Contributte\GopayInline\Utils\Money;
 
 class Eet extends AbstractObject
 {

--- a/src/Api/Objects/Item.php
+++ b/src/Api/Objects/Item.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Markette\GopayInline\Api\Objects;
+namespace Contributte\GopayInline\Api\Objects;
 
-use Markette\GopayInline\Utils\Money;
+use Contributte\GopayInline\Utils\Money;
 
 class Item extends AbstractObject
 {

--- a/src/Api/Objects/Parameter.php
+++ b/src/Api/Objects/Parameter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Objects;
+namespace Contributte\GopayInline\Api\Objects;
 
 class Parameter extends AbstractObject
 {

--- a/src/Api/Objects/Payer.php
+++ b/src/Api/Objects/Payer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Objects;
+namespace Contributte\GopayInline\Api\Objects;
 
 class Payer extends AbstractObject
 {

--- a/src/Api/Objects/Recurrence.php
+++ b/src/Api/Objects/Recurrence.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api\Objects;
+namespace Contributte\GopayInline\Api\Objects;
 
 class Recurrence extends AbstractObject
 {

--- a/src/Api/Objects/Target.php
+++ b/src/Api/Objects/Target.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Markette\GopayInline\Api\Objects;
+namespace Contributte\GopayInline\Api\Objects;
 
-use Markette\GopayInline\Api\Lists\TargetType;
+use Contributte\GopayInline\Api\Lists\TargetType;
 
 class Target extends AbstractObject
 {

--- a/src/Api/Token.php
+++ b/src/Api/Token.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Api;
+namespace Contributte\GopayInline\Api;
 
 class Token
 {

--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Markette\GopayInline\Auth;
+namespace Contributte\GopayInline\Auth;
 
-use Markette\GopayInline\Http\Response;
+use Contributte\GopayInline\Http\Response;
 
 interface Auth
 {

--- a/src/Auth/Oauth2Client.php
+++ b/src/Auth/Oauth2Client.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Markette\GopayInline\Auth;
+namespace Contributte\GopayInline\Auth;
 
-use Markette\GopayInline\Api\Gateway;
-use Markette\GopayInline\Client;
-use Markette\GopayInline\Exception\AuthorizationException;
-use Markette\GopayInline\Http\Http;
-use Markette\GopayInline\Http\HttpClient;
-use Markette\GopayInline\Http\Request;
-use Markette\GopayInline\Http\Response;
+use Contributte\GopayInline\Api\Gateway;
+use Contributte\GopayInline\Client;
+use Contributte\GopayInline\Exception\AuthorizationException;
+use Contributte\GopayInline\Http\Http;
+use Contributte\GopayInline\Http\HttpClient;
+use Contributte\GopayInline\Http\Request;
+use Contributte\GopayInline\Http\Response;
 
 class Oauth2Client implements Auth
 {

--- a/src/Bridges/Nette/DI/GopayExtension.php
+++ b/src/Bridges/Nette/DI/GopayExtension.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Markette\GopayInline\Bridges\Nette\DI;
+namespace Contributte\GopayInline\Bridges\Nette\DI;
 
-use Markette\GopayInline\Client;
-use Markette\GopayInline\Config;
+use Contributte\GopayInline\Client;
+use Contributte\GopayInline\Config;
 use Nette\DI\CompilerExtension;
 use Nette\DI\Statement;
 use Nette\Utils\Validators;

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace Markette\GopayInline;
+namespace Contributte\GopayInline;
 
-use Markette\GopayInline\Api\Token;
-use Markette\GopayInline\Auth\Auth;
-use Markette\GopayInline\Auth\Oauth2Client;
-use Markette\GopayInline\Exception\GopayException;
-use Markette\GopayInline\Http\Http;
-use Markette\GopayInline\Http\HttpClient;
-use Markette\GopayInline\Http\Request;
-use Markette\GopayInline\Http\Response;
-use Markette\GopayInline\Service\AccountsService;
-use Markette\GopayInline\Service\AuthenticationService;
-use Markette\GopayInline\Service\PaymentsService;
+use Contributte\GopayInline\Api\Token;
+use Contributte\GopayInline\Auth\Auth;
+use Contributte\GopayInline\Auth\Oauth2Client;
+use Contributte\GopayInline\Exception\GopayException;
+use Contributte\GopayInline\Http\Http;
+use Contributte\GopayInline\Http\HttpClient;
+use Contributte\GopayInline\Http\Request;
+use Contributte\GopayInline\Http\Response;
+use Contributte\GopayInline\Service\AccountsService;
+use Contributte\GopayInline\Service\AuthenticationService;
+use Contributte\GopayInline\Service\PaymentsService;
 
 /**
  * @property-read PaymentsService $payments

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Markette\GopayInline;
+namespace Contributte\GopayInline;
 
-use Markette\GopayInline\Api\Gateway;
+use Contributte\GopayInline\Api\Gateway;
 
 class Config
 {

--- a/src/Exception/AuthorizationException.php
+++ b/src/Exception/AuthorizationException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Exception;
+namespace Contributte\GopayInline\Exception;
 
 class AuthorizationException extends HttpException
 {

--- a/src/Exception/GopayException.php
+++ b/src/Exception/GopayException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Exception;
+namespace Contributte\GopayInline\Exception;
 
 use RuntimeException;
 

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Exception;
+namespace Contributte\GopayInline\Exception;
 
 use stdClass;
 

--- a/src/Exception/InvalidStateException.php
+++ b/src/Exception/InvalidStateException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Exception;
+namespace Contributte\GopayInline\Exception;
 
 class InvalidStateException extends GopayException
 {

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Exception;
+namespace Contributte\GopayInline\Exception;
 
 class ValidationException extends GopayException
 {

--- a/src/Http/Curl.php
+++ b/src/Http/Curl.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Http;
+namespace Contributte\GopayInline\Http;
 
 class Curl implements Io
 {

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Http;
+namespace Contributte\GopayInline\Http;
 
 interface Http
 {

--- a/src/Http/HttpClient.php
+++ b/src/Http/HttpClient.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Markette\GopayInline\Http;
+namespace Contributte\GopayInline\Http;
 
-use Markette\GopayInline\Exception\HttpException;
+use Contributte\GopayInline\Exception\HttpException;
 
 class HttpClient implements Http
 {

--- a/src/Http/Io.php
+++ b/src/Http/Io.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Http;
+namespace Contributte\GopayInline\Http;
 
 interface Io
 {

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Http;
+namespace Contributte\GopayInline\Http;
 
 class Request
 {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Http;
+namespace Contributte\GopayInline\Http;
 
 use RecursiveArrayIterator;
 

--- a/src/Service/AbstractPaymentService.php
+++ b/src/Service/AbstractPaymentService.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Markette\GopayInline\Service;
+namespace Contributte\GopayInline\Service;
 
-use Markette\GopayInline\Api\Entity\Payment;
-use Markette\GopayInline\Api\Lists\TargetType;
-use Markette\GopayInline\Api\Objects\Target;
+use Contributte\GopayInline\Api\Entity\Payment;
+use Contributte\GopayInline\Api\Lists\TargetType;
+use Contributte\GopayInline\Api\Objects\Target;
 
 abstract class AbstractPaymentService extends AbstractService
 {

--- a/src/Service/AbstractService.php
+++ b/src/Service/AbstractService.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Markette\GopayInline\Service;
+namespace Contributte\GopayInline\Service;
 
-use Markette\GopayInline\Api\Gateway;
-use Markette\GopayInline\Api\Lists\Scope;
-use Markette\GopayInline\Client;
-use Markette\GopayInline\Exception\InvalidStateException;
-use Markette\GopayInline\Http\Http;
-use Markette\GopayInline\Http\HttpClient;
-use Markette\GopayInline\Http\Request;
-use Markette\GopayInline\Http\Response;
+use Contributte\GopayInline\Api\Gateway;
+use Contributte\GopayInline\Api\Lists\Scope;
+use Contributte\GopayInline\Client;
+use Contributte\GopayInline\Exception\InvalidStateException;
+use Contributte\GopayInline\Http\Http;
+use Contributte\GopayInline\Http\HttpClient;
+use Contributte\GopayInline\Http\Request;
+use Contributte\GopayInline\Http\Response;
 
 abstract class AbstractService
 {

--- a/src/Service/AccountsService.php
+++ b/src/Service/AccountsService.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Markette\GopayInline\Service;
+namespace Contributte\GopayInline\Service;
 
-use Markette\GopayInline\Http\Response;
+use Contributte\GopayInline\Http\Response;
 
 class AccountsService extends AbstractService
 {

--- a/src/Service/AuthenticationService.php
+++ b/src/Service/AuthenticationService.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Markette\GopayInline\Service;
+namespace Contributte\GopayInline\Service;
 
-use Markette\GopayInline\Api\Lists\Scope;
-use Markette\GopayInline\Exception\HttpException;
+use Contributte\GopayInline\Api\Lists\Scope;
+use Contributte\GopayInline\Exception\HttpException;
 
 class AuthenticationService extends AbstractService
 {

--- a/src/Service/PaymentsService.php
+++ b/src/Service/PaymentsService.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Markette\GopayInline\Service;
+namespace Contributte\GopayInline\Service;
 
-use Markette\GopayInline\Api\Entity\Payment;
-use Markette\GopayInline\Api\Entity\PreauthorizedPayment;
-use Markette\GopayInline\Api\Entity\RecurrentPayment;
-use Markette\GopayInline\Api\Entity\RecurringPayment;
-use Markette\GopayInline\Http\Http;
-use Markette\GopayInline\Http\Response;
+use Contributte\GopayInline\Api\Entity\Payment;
+use Contributte\GopayInline\Api\Entity\PreauthorizedPayment;
+use Contributte\GopayInline\Api\Entity\RecurrentPayment;
+use Contributte\GopayInline\Api\Entity\RecurringPayment;
+use Contributte\GopayInline\Http\Http;
+use Contributte\GopayInline\Http\Response;
 
 class PaymentsService extends AbstractPaymentService
 {

--- a/src/Utils/Money.php
+++ b/src/Utils/Money.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Utils;
+namespace Contributte\GopayInline\Utils;
 
 final class Money
 {

--- a/src/Utils/Validator.php
+++ b/src/Utils/Validator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Markette\GopayInline\Utils;
+namespace Contributte\GopayInline\Utils;
 
 final class Validator
 {

--- a/tests/cases/unit/Api/Entity/Payment.phpt
+++ b/tests/cases/unit/Api/Entity/Payment.phpt
@@ -4,11 +4,11 @@
  * Test: Api\Entity\Payment
  */
 
-use Markette\GopayInline\Api\Entity\Payment;
-use Markette\GopayInline\Api\Objects\Item;
-use Markette\GopayInline\Api\Objects\Parameter;
-use Markette\GopayInline\Api\Objects\Payer;
-use Markette\GopayInline\Api\Objects\Target;
+use Contributte\GopayInline\Api\Entity\Payment;
+use Contributte\GopayInline\Api\Objects\Item;
+use Contributte\GopayInline\Api\Objects\Parameter;
+use Contributte\GopayInline\Api\Objects\Payer;
+use Contributte\GopayInline\Api\Objects\Target;
 use Tester\Assert;
 
 require __DIR__ . '/../../../../bootstrap.php';

--- a/tests/cases/unit/Api/Entity/PaymentFactory.phpt
+++ b/tests/cases/unit/Api/Entity/PaymentFactory.phpt
@@ -3,12 +3,12 @@
 /**
  * Test: Api\Entity\PaymentFactory
  */
-use Markette\GopayInline\Api\Entity\Payment;
-use Markette\GopayInline\Api\Entity\PaymentFactory;
-use Markette\GopayInline\Api\Lists\PaymentType;
-use Markette\GopayInline\Api\Lists\TargetType;
-use Markette\GopayInline\Api\Objects\Eet;
-use Markette\GopayInline\Exception\ValidationException;
+use Contributte\GopayInline\Api\Entity\Payment;
+use Contributte\GopayInline\Api\Entity\PaymentFactory;
+use Contributte\GopayInline\Api\Lists\PaymentType;
+use Contributte\GopayInline\Api\Lists\TargetType;
+use Contributte\GopayInline\Api\Objects\Eet;
+use Contributte\GopayInline\Exception\ValidationException;
 use Tester\Assert;
 
 require __DIR__ . '/../../../../bootstrap.php';

--- a/tests/cases/unit/Api/Entity/PreauthorizedPayment.phpt
+++ b/tests/cases/unit/Api/Entity/PreauthorizedPayment.phpt
@@ -4,8 +4,8 @@
  * Test: Api\Entity\PreauthorizedPayment
  */
 
-use Markette\GopayInline\Api\Entity\PreauthorizedPayment;
-use Markette\GopayInline\Api\Objects\Target;
+use Contributte\GopayInline\Api\Entity\PreauthorizedPayment;
+use Contributte\GopayInline\Api\Objects\Target;
 use Tester\Assert;
 
 require __DIR__ . '/../../../../bootstrap.php';

--- a/tests/cases/unit/Api/Entity/RecurrentPayment.phpt
+++ b/tests/cases/unit/Api/Entity/RecurrentPayment.phpt
@@ -4,10 +4,10 @@
  * Test: Api\Entity\RecurrentPayment
  */
 
-use Markette\GopayInline\Api\Entity\RecurrentPayment;
-use Markette\GopayInline\Api\Lists\RecurrenceCycle;
-use Markette\GopayInline\Api\Objects\Recurrence;
-use Markette\GopayInline\Api\Objects\Target;
+use Contributte\GopayInline\Api\Entity\RecurrentPayment;
+use Contributte\GopayInline\Api\Lists\RecurrenceCycle;
+use Contributte\GopayInline\Api\Objects\Recurrence;
+use Contributte\GopayInline\Api\Objects\Target;
 use Tester\Assert;
 
 require __DIR__ . '/../../../../bootstrap.php';

--- a/tests/cases/unit/Api/Entity/RecurrentPaymentFactory.phpt
+++ b/tests/cases/unit/Api/Entity/RecurrentPaymentFactory.phpt
@@ -3,13 +3,13 @@
 /**
  * Test: Api\Entity\RecurrentPaymentFactory
  */
-use Markette\GopayInline\Api\Entity\RecurrentPayment;
-use Markette\GopayInline\Api\Entity\RecurrentPaymentFactory;
-use Markette\GopayInline\Api\Lists\PaymentType;
-use Markette\GopayInline\Api\Lists\RecurrenceCycle;
-use Markette\GopayInline\Api\Lists\TargetType;
-use Markette\GopayInline\Api\Objects\Eet;
-use Markette\GopayInline\Exception\ValidationException;
+use Contributte\GopayInline\Api\Entity\RecurrentPayment;
+use Contributte\GopayInline\Api\Entity\RecurrentPaymentFactory;
+use Contributte\GopayInline\Api\Lists\PaymentType;
+use Contributte\GopayInline\Api\Lists\RecurrenceCycle;
+use Contributte\GopayInline\Api\Lists\TargetType;
+use Contributte\GopayInline\Api\Objects\Eet;
+use Contributte\GopayInline\Exception\ValidationException;
 use Tester\Assert;
 
 require __DIR__ . '/../../../../bootstrap.php';

--- a/tests/cases/unit/Api/Entity/RecurringPayment.phpt
+++ b/tests/cases/unit/Api/Entity/RecurringPayment.phpt
@@ -4,11 +4,11 @@
  * Test: Api\Entity\RecurringPayment
  */
 
-use Markette\GopayInline\Api\Entity\RecurringPayment;
-use Markette\GopayInline\Api\Objects\Item;
-use Markette\GopayInline\Api\Objects\Parameter;
-use Markette\GopayInline\Api\Objects\Payer;
-use Markette\GopayInline\Api\Objects\Target;
+use Contributte\GopayInline\Api\Entity\RecurringPayment;
+use Contributte\GopayInline\Api\Objects\Item;
+use Contributte\GopayInline\Api\Objects\Parameter;
+use Contributte\GopayInline\Api\Objects\Payer;
+use Contributte\GopayInline\Api\Objects\Target;
 use Tester\Assert;
 
 require __DIR__ . '/../../../../bootstrap.php';

--- a/tests/cases/unit/Api/Entity/RecurringPaymentFactory.phpt
+++ b/tests/cases/unit/Api/Entity/RecurringPaymentFactory.phpt
@@ -3,10 +3,10 @@
 /**
  * Test: Api\Entity\RecurringPaymentFactory
  */
-use Markette\GopayInline\Api\Entity\RecurringPayment;
-use Markette\GopayInline\Api\Entity\RecurringPaymentFactory;
-use Markette\GopayInline\Api\Lists\PaymentType;
-use Markette\GopayInline\Exception\ValidationException;
+use Contributte\GopayInline\Api\Entity\RecurringPayment;
+use Contributte\GopayInline\Api\Entity\RecurringPaymentFactory;
+use Contributte\GopayInline\Api\Lists\PaymentType;
+use Contributte\GopayInline\Exception\ValidationException;
 use Tester\Assert;
 
 require __DIR__ . '/../../../../bootstrap.php';

--- a/tests/cases/unit/Api/Gateway.phpt
+++ b/tests/cases/unit/Api/Gateway.phpt
@@ -4,7 +4,7 @@
  * Test: Api\Gateway
  */
 
-use Markette\GopayInline\Api\Gateway;
+use Contributte\GopayInline\Api\Gateway;
 use Tester\Assert;
 
 require __DIR__ . '/../../../bootstrap.php';

--- a/tests/cases/unit/Api/Lists/PaymentInstrument.phpt
+++ b/tests/cases/unit/Api/Lists/PaymentInstrument.phpt
@@ -4,7 +4,7 @@
  * Test: Api\Lists\PaymentInstrument
  */
 
-use Markette\GopayInline\Api\Lists\PaymentInstrument;
+use Contributte\GopayInline\Api\Lists\PaymentInstrument;
 use Tester\Assert;
 
 require __DIR__ . '/../../../../bootstrap.php';

--- a/tests/cases/unit/Api/Lists/SwiftCode.phpt
+++ b/tests/cases/unit/Api/Lists/SwiftCode.phpt
@@ -4,7 +4,7 @@
  * Test: Api\Lists\SwiftCode
  */
 
-use Markette\GopayInline\Api\Lists\SwiftCode;
+use Contributte\GopayInline\Api\Lists\SwiftCode;
 use Tester\Assert;
 
 require __DIR__ . '/../../../../bootstrap.php';

--- a/tests/cases/unit/Api/Objects/Contact.phpt
+++ b/tests/cases/unit/Api/Objects/Contact.phpt
@@ -4,7 +4,7 @@
  * Test: Api\Lists\Objects\Contact
  */
 
-use Markette\GopayInline\Api\Objects\Contact;
+use Contributte\GopayInline\Api\Objects\Contact;
 use Tester\Assert;
 
 require __DIR__ . '/../../../../bootstrap.php';

--- a/tests/cases/unit/Api/Objects/Item.phpt
+++ b/tests/cases/unit/Api/Objects/Item.phpt
@@ -4,7 +4,7 @@
  * Test: Api\Objects\Item
  */
 
-use Markette\GopayInline\Api\Objects\Item;
+use Contributte\GopayInline\Api\Objects\Item;
 use Tester\Assert;
 
 require __DIR__ . '/../../../../bootstrap.php';

--- a/tests/cases/unit/Api/Objects/Payer.phpt
+++ b/tests/cases/unit/Api/Objects/Payer.phpt
@@ -4,8 +4,8 @@
  * Test: Api\Lists\Objects\Payer
  */
 
-use Markette\GopayInline\Api\Objects\Contact;
-use Markette\GopayInline\Api\Objects\Payer;
+use Contributte\GopayInline\Api\Objects\Contact;
+use Contributte\GopayInline\Api\Objects\Payer;
 use Tester\Assert;
 
 require __DIR__ . '/../../../../bootstrap.php';

--- a/tests/cases/unit/Api/Token.phpt
+++ b/tests/cases/unit/Api/Token.phpt
@@ -4,7 +4,7 @@
  * Test: Api\Token
  */
 
-use Markette\GopayInline\Api\Token;
+use Contributte\GopayInline\Api\Token;
 use Tester\Assert;
 
 require __DIR__ . '/../../../bootstrap.php';

--- a/tests/cases/unit/Auth/Oauth2Client.phpt
+++ b/tests/cases/unit/Auth/Oauth2Client.phpt
@@ -4,10 +4,10 @@
  * Test: Auth\Oauth2Client
  */
 
-use Markette\GopayInline\Auth\Oauth2Client;
-use Markette\GopayInline\Client;
-use Markette\GopayInline\Exception\AuthorizationException;
-use Markette\GopayInline\Http\HttpClient;
+use Contributte\GopayInline\Auth\Oauth2Client;
+use Contributte\GopayInline\Client;
+use Contributte\GopayInline\Exception\AuthorizationException;
+use Contributte\GopayInline\Http\HttpClient;
 use Tester\Assert;
 
 require __DIR__ . '/../../../bootstrap.php';

--- a/tests/cases/unit/Bridges/Nette/DI/GopayExtension.phpt
+++ b/tests/cases/unit/Bridges/Nette/DI/GopayExtension.phpt
@@ -4,8 +4,8 @@
  * Test: Bridges\Nette\DI\GopayExtension
  */
 
-use Markette\GopayInline\Bridges\Nette\DI\GopayExtension;
-use Markette\GopayInline\Client;
+use Contributte\GopayInline\Bridges\Nette\DI\GopayExtension;
+use Contributte\GopayInline\Client;
 use Nette\DI\Compiler;
 use Nette\DI\Container;
 use Nette\DI\ContainerLoader;

--- a/tests/cases/unit/Client.phpt
+++ b/tests/cases/unit/Client.phpt
@@ -4,16 +4,16 @@
  * Test: Client
  */
 
-use Markette\GopayInline\Api\Token;
-use Markette\GopayInline\Auth\Auth;
-use Markette\GopayInline\Client;
-use Markette\GopayInline\Config;
-use Markette\GopayInline\Exception\GopayException;
-use Markette\GopayInline\Http\Http;
-use Markette\GopayInline\Http\Request;
-use Markette\GopayInline\Http\Response;
-use Markette\GopayInline\Service\AccountsService;
-use Markette\GopayInline\Service\PaymentsService;
+use Contributte\GopayInline\Api\Token;
+use Contributte\GopayInline\Auth\Auth;
+use Contributte\GopayInline\Client;
+use Contributte\GopayInline\Config;
+use Contributte\GopayInline\Exception\GopayException;
+use Contributte\GopayInline\Http\Http;
+use Contributte\GopayInline\Http\Request;
+use Contributte\GopayInline\Http\Response;
+use Contributte\GopayInline\Service\AccountsService;
+use Contributte\GopayInline\Service\PaymentsService;
 use Tester\Assert;
 
 require __DIR__ . '/../../bootstrap.php';

--- a/tests/cases/unit/Config.phpt
+++ b/tests/cases/unit/Config.phpt
@@ -4,8 +4,8 @@
  * Test: Config
  */
 
-use Markette\GopayInline\Api\Gateway;
-use Markette\GopayInline\Config;
+use Contributte\GopayInline\Api\Gateway;
+use Contributte\GopayInline\Config;
 use Tester\Assert;
 
 require __DIR__ . '/../../bootstrap.php';

--- a/tests/cases/unit/Exception/HttpException.phpt
+++ b/tests/cases/unit/Exception/HttpException.phpt
@@ -4,7 +4,7 @@
  * Test: Exception/HttpException
  */
 
-use Markette\GopayInline\Exception\HttpException;
+use Contributte\GopayInline\Exception\HttpException;
 use Tester\Assert;
 
 require __DIR__ . '/../../../bootstrap.php';

--- a/tests/cases/unit/Http/HttpClient.phpt
+++ b/tests/cases/unit/Http/HttpClient.phpt
@@ -4,11 +4,11 @@
  * Test: Http\HttpClient
  */
 
-use Markette\GopayInline\Exception\HttpException;
-use Markette\GopayInline\Http\HttpClient;
-use Markette\GopayInline\Http\Io;
-use Markette\GopayInline\Http\Request;
-use Markette\GopayInline\Http\Response;
+use Contributte\GopayInline\Exception\HttpException;
+use Contributte\GopayInline\Http\HttpClient;
+use Contributte\GopayInline\Http\Io;
+use Contributte\GopayInline\Http\Request;
+use Contributte\GopayInline\Http\Response;
 use Tester\Assert;
 
 require __DIR__ . '/../../../bootstrap.php';

--- a/tests/cases/unit/Http/Request.phpt
+++ b/tests/cases/unit/Http/Request.phpt
@@ -4,7 +4,7 @@
  * Test: Http\Request
  */
 
-use Markette\GopayInline\Http\Request;
+use Contributte\GopayInline\Http\Request;
 use Tester\Assert;
 
 require __DIR__ . '/../../../bootstrap.php';

--- a/tests/cases/unit/Http/Response.phpt
+++ b/tests/cases/unit/Http/Response.phpt
@@ -4,7 +4,7 @@
  * Test: Http\Response
  */
 
-use Markette\GopayInline\Http\Response;
+use Contributte\GopayInline\Http\Response;
 use Tester\Assert;
 
 require __DIR__ . '/../../../bootstrap.php';

--- a/tests/cases/unit/Service/AbstractService.phpt
+++ b/tests/cases/unit/Service/AbstractService.phpt
@@ -6,12 +6,12 @@
 
 namespace Tests\Cases\Unit\Service;
 
-use Markette\GopayInline\Client;
-use Markette\GopayInline\Exception\InvalidStateException;
-use Markette\GopayInline\Http\Http;
-use Markette\GopayInline\Http\Request;
-use Markette\GopayInline\Http\Response;
-use Markette\GopayInline\Service\AbstractService;
+use Contributte\GopayInline\Client;
+use Contributte\GopayInline\Exception\InvalidStateException;
+use Contributte\GopayInline\Http\Http;
+use Contributte\GopayInline\Http\Request;
+use Contributte\GopayInline\Http\Response;
+use Contributte\GopayInline\Service\AbstractService;
 use Mockery;
 use RuntimeException;
 use Tester\Assert;

--- a/tests/cases/unit/Service/AccountsService.phpt
+++ b/tests/cases/unit/Service/AccountsService.phpt
@@ -4,11 +4,11 @@
  * Test: Service\PaymentService
  */
 
-use Markette\GopayInline\Api\Lists\Currency;
-use Markette\GopayInline\Api\Lists\Format;
-use Markette\GopayInline\Client;
-use Markette\GopayInline\Config;
-use Markette\GopayInline\Service\AccountsService;
+use Contributte\GopayInline\Api\Lists\Currency;
+use Contributte\GopayInline\Api\Lists\Format;
+use Contributte\GopayInline\Client;
+use Contributte\GopayInline\Config;
+use Contributte\GopayInline\Service\AccountsService;
 use Tester\Assert;
 
 require __DIR__ . '/../../../bootstrap.php';

--- a/tests/cases/unit/Service/AuthenticationService.phpt
+++ b/tests/cases/unit/Service/AuthenticationService.phpt
@@ -4,10 +4,10 @@
  * Test: Service\AuthenticationService
  */
 
-use Markette\GopayInline\Client;
-use Markette\GopayInline\Config;
-use Markette\GopayInline\Exception\HttpException;
-use Markette\GopayInline\Service\AuthenticationService;
+use Contributte\GopayInline\Client;
+use Contributte\GopayInline\Config;
+use Contributte\GopayInline\Exception\HttpException;
+use Contributte\GopayInline\Service\AuthenticationService;
 use Tester\Assert;
 
 require __DIR__ . '/../../../bootstrap.php';

--- a/tests/cases/unit/Service/PaymentService.phpt
+++ b/tests/cases/unit/Service/PaymentService.phpt
@@ -4,20 +4,20 @@
  * Test: Service\PaymentService
  */
 
-use Markette\GopayInline\Api\Entity\Payment;
-use Markette\GopayInline\Api\Entity\PreauthorizedPayment;
-use Markette\GopayInline\Api\Entity\RecurrentPayment;
-use Markette\GopayInline\Api\Entity\RecurringPayment;
-use Markette\GopayInline\Api\Lists\Currency;
-use Markette\GopayInline\Api\Lists\PaymentType;
-use Markette\GopayInline\Api\Lists\TargetType;
-use Markette\GopayInline\Api\Objects\Eet;
-use Markette\GopayInline\Api\Objects\Item;
-use Markette\GopayInline\Api\Objects\Target;
-use Markette\GopayInline\Client;
-use Markette\GopayInline\Config;
-use Markette\GopayInline\Http\Http;
-use Markette\GopayInline\Service\PaymentsService;
+use Contributte\GopayInline\Api\Entity\Payment;
+use Contributte\GopayInline\Api\Entity\PreauthorizedPayment;
+use Contributte\GopayInline\Api\Entity\RecurrentPayment;
+use Contributte\GopayInline\Api\Entity\RecurringPayment;
+use Contributte\GopayInline\Api\Lists\Currency;
+use Contributte\GopayInline\Api\Lists\PaymentType;
+use Contributte\GopayInline\Api\Lists\TargetType;
+use Contributte\GopayInline\Api\Objects\Eet;
+use Contributte\GopayInline\Api\Objects\Item;
+use Contributte\GopayInline\Api\Objects\Target;
+use Contributte\GopayInline\Client;
+use Contributte\GopayInline\Config;
+use Contributte\GopayInline\Http\Http;
+use Contributte\GopayInline\Service\PaymentsService;
 use Tester\Assert;
 
 require __DIR__ . '/../../../bootstrap.php';


### PR DESCRIPTION
I guess you have to rename the package on coveralls.io.

I'd rather merge #52 ~~#44~~ and either #42 or #43 (depends on which one you prefer) before upgrading the minimal php version and versions of other packages (including phpstan and other qa stuff).

Upgrade of dependencies would go to 2.x version.

closes #50 