### PR TITLE
PaymentsService: add method to capture preauthorized payment

### DIFF
--- a/src/Service/PaymentsService.php
+++ b/src/Service/PaymentsService.php
@@ -92,6 +92,22 @@ class PaymentsService extends AbstractPaymentService
 	}
 
 	/**
+	 * @param int|float $id
+	 * @param float $amount
+	 * @return Response
+	 */
+	public function capturePayment($id, $amount = NULL)
+	{
+		$data = [];
+
+		if ($amount !== NULL) {
+			$data['amount'] = round($amount * 100);
+		}
+
+		return $this->makeRequest('POST', 'payments/payment/' . $id . '/capture', $data);
+	}
+
+	/**
 	 * @param string $currency
 	 * @return Response
 	 */

--- a/tests/cases/unit/Service/PaymentService.phpt
+++ b/tests/cases/unit/Service/PaymentService.phpt
@@ -16,6 +16,7 @@ use Contributte\GopayInline\Api\Objects\Target;
 use Contributte\GopayInline\Client;
 use Contributte\GopayInline\Config;
 use Contributte\GopayInline\Http\Http;
+use Contributte\GopayInline\Http\Response;
 use Contributte\GopayInline\Service\PaymentsService;
 use Tester\Assert;
 
@@ -208,4 +209,22 @@ test(function () {
 		->andReturn(TRUE);
 
 	Assert::true($service->getEetReceipts(99));
+});
+
+// Capture payment
+test(function () {
+	$client = new Client(new Config(1, 2, 3));
+	$response = new Response;
+	$response->setData([
+		'id' => 10001,
+		'status' => 'FINISHED',
+	]);
+	$service = Mockery::mock(PaymentsService::class, [$client])
+		->makePartial()
+		->shouldAllowMockingProtectedMethods();
+	$service->shouldReceive('makeRequest')
+		->with('POST', 'payments/payment/10001/capture', ['amount' => 3150.])
+		->andReturn($response);
+
+	Assert::type(Response::class, $service->capturePayment(10001, 31.5));
 });


### PR DESCRIPTION
Should replace #44 since it contained extra commit and this implementation allows to call the API without parameters (i.e. capture the whole payment).