### PR TITLE
Support for Nette 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"ninjify/nunjuck": "^0.1.4",
 		"nette/tester": "^1.7.0",
 		"mockery/mockery": "^0.9.6",
-		"nette/di": "^2.4.4"
+		"nette/di": "^2.4.4|^3.0"
 	},
 	"suggest": {
 		"nette/di": "For GopayExtension"

--- a/src/Bridges/Nette/DI/GopayExtension.php
+++ b/src/Bridges/Nette/DI/GopayExtension.php
@@ -5,7 +5,7 @@ namespace Contributte\GopayInline\Bridges\Nette\DI;
 use Contributte\GopayInline\Client;
 use Contributte\GopayInline\Config;
 use Nette\DI\CompilerExtension;
-use Nette\DI\Definitions\Statement;
+use Nette\DI\Statement;
 use Nette\Utils\Validators;
 
 class GopayExtension extends CompilerExtension

--- a/src/Bridges/Nette/DI/GopayExtension.php
+++ b/src/Bridges/Nette/DI/GopayExtension.php
@@ -5,7 +5,7 @@ namespace Contributte\GopayInline\Bridges\Nette\DI;
 use Contributte\GopayInline\Client;
 use Contributte\GopayInline\Config;
 use Nette\DI\CompilerExtension;
-use Nette\DI\Statement;
+use Nette\DI\Definitions\Statement;
 use Nette\Utils\Validators;
 
 class GopayExtension extends CompilerExtension
@@ -35,7 +35,7 @@ class GopayExtension extends CompilerExtension
 		Validators::assertField($config, 'test', 'bool');
 
 		$builder->addDefinition($this->prefix('client'))
-			->setClass(Client::class, [
+			->setFactory(Client::class, [
 				new Statement(Config::class, [
 					$config['goId'],
 					$config['clientId'],


### PR DESCRIPTION
Maintains coding standards, constraint added to composer.json. 

Closes #48