### PR TITLE
travis: update PHP 7.4 build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 env:
   - CODE_CHECKER_VERSION=^3.1
@@ -14,7 +14,7 @@ matrix:
   fast_finish: true
 
   allow_failures:
-    - php: 7.4snapshot
+    - php: 7.4
 
   include:
     - php: 5.6


### PR DESCRIPTION
In TravisCI exists stable 7.4 version.