### PR TITLE
Add VUB_BANK back to SwiftCode constants

### DIFF
--- a/src/Api/Lists/SwiftCode.php
+++ b/src/Api/Lists/SwiftCode.php
@@ -22,6 +22,7 @@ class SwiftCode
 	public const SLOVENSKA_SPORITELNA = 'GIBASKBX';
 	public const TATRA_BANKA = 'TATRSKBX';
 	public const UNICREDIT_BANK_SK = 'UNCRSKBX';
+	public const VUB_BANK = 'SUBASKBX';
 
 	/**
 	 * @return string[]
@@ -58,6 +59,7 @@ class SwiftCode
 			self::SLOVENSKA_SPORITELNA,
 			self::TATRA_BANKA,
 			self::UNICREDIT_BANK_SK,
+			self::VUB_BANK,
 		];
 	}
 

--- a/tests/cases/unit/Api/Lists/SwiftCode.phpt
+++ b/tests/cases/unit/Api/Lists/SwiftCode.phpt
@@ -11,7 +11,7 @@ require __DIR__ . '/../../../../bootstrap.php';
 
 // All
 test(function (): void {
-	Assert::count(13, SwiftCode::all());
+	Assert::count(14, SwiftCode::all());
 });
 
 // CZ
@@ -21,5 +21,5 @@ test(function (): void {
 
 // SK
 test(function (): void {
-	Assert::count(4, SwiftCode::sk());
+	Assert::count(5, SwiftCode::sk());
 });


### PR DESCRIPTION
"Všeobecná úverová banka" with key SUBASKBX is still in offical gopay documentation and works just fine
https://doc.gopay.com/cs/#swift