### PR TITLE
Fix partial capture

### DIFF
--- a/src/Service/PaymentsService.php
+++ b/src/Service/PaymentsService.php
@@ -73,15 +73,20 @@ class PaymentsService extends AbstractPaymentService
 	}
 
 	/**
-	 * @param int|float $id
+	 * @param int|float    $id
+	 * @param float|null   $amount
+	 * @param mixed[]|null $items
 	 */
-	public function capturePayment($id, ?float $amount = null): Response
+	public function capturePayment($id, ?float $amount = null, ?array $items = null): Response
 	{
-		$data = [];
-
-		if ($amount !== null) {
-			$data['amount'] = round($amount * 100);
+		if ($amount === null || $items === null) {
+			return $this->makeRequest('POST', 'payments/payment/' . $id . '/capture');
 		}
+
+		$data = array_merge(
+			['amount' => round($amount * 100)],
+			['items' => $items]
+		);
 
 		return $this->makeRequest('POST', 'payments/payment/' . $id . '/capture', $data);
 	}

--- a/tests/cases/unit/Service/PaymentService.phpt
+++ b/tests/cases/unit/Service/PaymentService.phpt
@@ -229,8 +229,8 @@ test(function (): void {
 		->makePartial()
 		->shouldAllowMockingProtectedMethods();
 	$service->shouldReceive('makeRequest')
-		->with('POST', 'payments/payment/10001/capture', ['amount' => 3150.])
+		->with('POST', 'payments/payment/10001/capture')
 		->andReturn($response);
 
-	Assert::type(Response::class, $service->capturePayment(10001, 31.5));
+	Assert::type(Response::class, $service->capturePayment(10001));
 });


### PR DESCRIPTION
Partial payment capture has required new list of paid items(https://doc.gopay.com/cs/?lang=shell#castecne-strzeni-predautorizovane-platby). 
