### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ tests:
 
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Replace the Makefile coverage target to run Tester with `php` instead of `phpdbg` so this repository matches the org-wide coverage migration tracked in #73.

## Motivation

Issue #73 is standardizing coverage targets away from `phpdbg` across Contributte repositories.

## Changes

- replace `-p phpdbg` with `-p php` in both `coverage` target variants in `Makefile`

## Testing

- [x] `composer update --no-interaction`
- [ ] `make coverage` - blocked locally because this environment has no Xdebug, PCOV, or PHPDBG available for coverage collection
- [ ] `make tests` - fails on PHP 8.5 because `ninjify/nunjuck` calls deprecated `lcg_value()` during test bootstrap